### PR TITLE
Make viewrendered.py import errors explicit.

### DIFF
--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -295,6 +295,12 @@ def init():
     global got_docutils
     ok = bool(got_docutils and QtSvg and QtWebKitWidgets)
     if not ok:
+        ok = bool(QtSvg)
+        if not ok:
+            g.es('Warning: viewrendered.py running without QtSvg.')
+        ok = bool(QtWebKitWidgets)
+        if not ok:
+            g.es('Warning: viewrendered.py running without QtWebKitWidgets.')
         g.es_print('Warning: viewrendered.py running without docutils.')
     # Always enable this plugin, even if imports fail.
     g.plugin_signon(__name__)


### PR DESCRIPTION
This is my first time trying to help out with Leo. I apologize if I get anything wrong. I thought adding explicit error messages regarding viewrendered.py imports would be helpful. I recently switched to linux mint 18 and the QtSvg and QtWebKit modules were not installed by default, so the error messages would have been helpful.

tscv11